### PR TITLE
docs: agregar estructura inicial de documentación

### DIFF
--- a/docs/mgmt/README.md
+++ b/docs/mgmt/README.md
@@ -1,0 +1,4 @@
+# Management Plan (MGMT)
+
+Este documento describe la planificación de gestión del proyecto **CyberShield AI**.  
+Incluye aspectos de organización, cronograma, roles, recursos y comunicación del equipo.

--- a/docs/sdd/README.md
+++ b/docs/sdd/README.md
@@ -1,0 +1,3 @@
+# Software Design Document (SDD)
+
+Este documento contiene el diseño detallado del sistema CyberShield AI.

--- a/docs/srs/README.md
+++ b/docs/srs/README.md
@@ -1,0 +1,1 @@
+# Especificación de Requisitos (SRS)

--- a/docs/testplan/README.md
+++ b/docs/testplan/README.md
@@ -1,0 +1,4 @@
+# Test Plan
+
+Este documento contiene el plan de pruebas del sistema **CyberShield AI**.  
+Incluye los objetivos de prueba, alcance, casos de prueba, criterios de aceptación y responsabilidades.


### PR DESCRIPTION
Este PR agrega los directorios iniciales para la documentación del proyecto:
- docs/srs
- docs/sdd
- docs/mgmt
- docs/testplan
Cada carpeta contiene un README.md para estructurar los documentos.
